### PR TITLE
Updating the cron expression for better results in CloudWatch

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -36,7 +36,7 @@ functions:
     #   - schedule:
     #       name: lambda-ping-${opt:stage}-5min
     #       description: 'Ping HTTP endpoints every 5 minutes'
-    #       rate: rate(5 minutes)
+    #       rate: cron(1,6,11,16,21,26,31,36,41,46,51,56 * * * ? *)
     #       enabled: true
     #       input:
     #         - 'https://www.jethrocarr.com'


### PR DESCRIPTION
Thanks for building this! 

This cron() expression works better than using the rate() expression. I found that when using rate() CloudWatch events would frequently be invoked early resulting in two samples in the same 5 minute period.

This is the sample count at a 5 minute interval before and after the change in my environment:
![image](https://user-images.githubusercontent.com/18078751/92047905-8fd64f00-ed43-11ea-9760-f3be21bfcff0.png)
